### PR TITLE
Use case-sensitive plugin names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ allprojects {
         updateSinceUntilBuild = false
         instrumentCode = false
         ideaDependencyCachePath = file("deps").absolutePath
-        setPlugins("properties", "maven", "junit", "kotlin", "android", "gradle", "groovy")
+        setPlugins("properties", "maven", "junit", "Kotlin", "android", "gradle", "Groovy")
     }
 
     tasks.withType<KotlinCompile> {


### PR DESCRIPTION
Linux is picky about idea plugin casing.

Fixes https://github.com/Ruin0x11/intellij-lsp-server/issues/41